### PR TITLE
Patch breaking datasets version

### DIFF
--- a/src/tasksource/tasks.py
+++ b/src/tasksource/tasks.py
@@ -304,11 +304,11 @@ art = MultipleChoice(cat(['hypothesis_1','hypothesis_2']),
     splits=['train','validation',None]
 )
 
-
-mmlu = MultipleChoice('question',labels='answer',choices_list='choices',splits=['validation','dev','test'],
-    dataset_name="tasksource/mmlu",
-    config_name=get_dataset_config_names("tasksource/mmlu")
-)
+# tasksource/mmlu not compatible with parquet
+# mmlu = MultipleChoice('question',labels='answer',choices_list='choices',splits=['validation','dev','test'],
+#    dataset_name="tasksource/mmlu",
+#    config_name=get_dataset_config_names("tasksource/mmlu")
+#)
 
 winogrande = MultipleChoice('sentence',['option1','option2'],'answer',config_name='winogrande_xl',
     splits=['train','validation',None])


### PR DESCRIPTION
Hi, due to recent datasets update to [4.0.0](https://github.com/huggingface/datasets/releases/tag/4.0.0), `tasksource/mmlu` format is not supported anymore (see [this comment](https://github.com/huggingface/datasets/issues/7675#issuecomment-3053565137)). This is breaking as you cannot import tasksource once it has been installed with datasets.

You can reproduce it with `pip install -U datasets & python -c 'import tasksource'`

I commented the breaking dataset, another solution could be to convert this dataset to parquet on the HF hub.